### PR TITLE
CARF-113 | Removed fullStop from messages for agentSignInProblem

### DIFF
--- a/app/views/AgentSignInProblemView.scala.html
+++ b/app/views/AgentSignInProblemView.scala.html
@@ -32,5 +32,5 @@
     <p class="govuk-body">@messages("agentSignInProblem.paragraph")</p>
 
     <p class="govuk-body">@messages("agentSignInProblem.linkText")
-        @link(s"${appConfig.signOutUrl}?continue=${appConfig.loginContinueUrl}", messages("agentSignInProblem.link"))</p>
+        @link(s"${appConfig.signOutUrl}?continue=${appConfig.loginContinueUrl}", messages("agentSignInProblem.link"), fullStop = true)</p>
 }

--- a/app/views/components/Link.scala.html
+++ b/app/views/components/Link.scala.html
@@ -16,6 +16,6 @@
 
 @this()
 
-@(href: String, key: String, id: Option[String] = None, openInNewWindow: Boolean = false, classes: String = "govuk-link")(implicit messages: Messages)
+@(href: String, key: String, id: Option[String] = None, openInNewWindow: Boolean = false, classes: String = "govuk-link", fullStop: Boolean = false)(implicit messages: Messages)
 
-<a class="@classes" @if(id.isDefined){id="@id"} href="@href" @if(openInNewWindow) {target="_blank" rel="noopener noreferrer"}>@messages(key)</a>
+<a class="@classes" @if(id.isDefined){id="@id"} href="@href" @if(openInNewWindow) {target="_blank" rel="noopener noreferrer"}>@messages(key)</a>@if(fullStop){.}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -104,4 +104,4 @@ agentSignInProblem.title = You’re unable to use this service with this Governm
 agentSignInProblem.heading = You’re unable to use this service with this Government Gateway user ID
 agentSignInProblem.paragraph = You have signed in with an agent Government Gateway user ID.
 agentSignInProblem.linkText = To use this service as an agent, you must
-agentSignInProblem.link = sign in with an organisation or individual Government Gateway user ID.
+agentSignInProblem.link = sign in with an organisation or individual Government Gateway user ID


### PR DESCRIPTION
This PR is contains an updated version of Link.scala.html to handle fullstops dynamically, by passing a boolean parameter for fullstops. It also contains the removal of fullStop from agentSignInProblem page