### PR TITLE
CARF-163 use lowercase 'y' in messages.en haveNiNumber.error.required = 'Select yes...'

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -96,7 +96,7 @@ yourUniqueTaxpayerReference.change.hidden = Change your Corporation Tax Unique T
 haveNiNumber.title = Do you have a National Insurance number?
 haveNiNumber.heading = Do you have a National Insurance number?
 haveNiNumber.checkYourAnswersLabel = Do you have a National Insurance number?
-haveNiNumber.error.required = Select Yes if you have a National Insurance number
+haveNiNumber.error.required = Select yes if you have a National Insurance number
 haveNiNumber.change.hidden = Change if you have a National Insurance number
 haveNiNumber.linktext = Find your National Insurance number (opens in new tab)
 


### PR DESCRIPTION
CARF-163 use lowercase 'y' in messages.en haveNiNumber.error.required = 'Select yes...'