### PR TITLE
CARF-468: Added connection for Subscription Display API Calls

### DIFF
--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -49,7 +49,7 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
       s"[SubscriptionConnector] Creating subscription with request:\n ${Json.prettyPrint(Json.toJson(createSubscriptionRequest))}"
     )
 
-    EitherT {
+    ResultT.fromFuture(
       http
         .post(submissionUrl)
         .withBody(Json.toJson(createSubscriptionRequest))
@@ -70,7 +70,7 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
           logger.error(s"Future Failed to complete due to: ${e.getMessage}")
           Left(InternalServerError)
         }
-    }
+    )
   }
 
   def displaySubscription(
@@ -82,7 +82,7 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
       s"[SubscriptionConnector] Displaying subscription with ID: $carfId"
     )
 
-    EitherT {
+    ResultT.fromFuture(
       http
         .get(baseUrl)
         .execute[HttpResponse]
@@ -104,9 +104,8 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
               logger.warn(s"Unexpected response: status code: ${httpResponse.status}, from endpoint: ${baseUrl.toURI}")
               Left(InternalServerError)
           }
-
         }
-    }
+    )
   }
 
   private def handleErrorResponse(response: HttpResponse): ApiError = {

--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -22,9 +22,9 @@ import models.SubscriptionId
 import models.error.ApiError
 import models.error.ApiError.{AlreadyRegisteredError, InternalServerError, UnableToCreateSubscriptionError}
 import models.requests.CreateSubscriptionRequest
-import models.responses.CreateSubscriptionResponse
+import models.responses.{CreateSubscriptionResponse, DisplaySubscriptionResponse}
 import play.api.Logging
-import play.api.http.Status.OK
+import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import types.ResultT
@@ -69,6 +69,42 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
         .recover { case NonFatal(e) =>
           logger.error(s"Future Failed to complete due to: ${e.getMessage}")
           Left(InternalServerError)
+        }
+    }
+  }
+
+  def displaySubscription(
+      carfId: String
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): ResultT[DisplaySubscriptionResponse] = {
+    val baseUrl = url"${config.carfRegistrationBaseUrl}/subscription/display/$carfId"
+
+    logger.debug(
+      s"[SubscriptionConnector] Displaying subscription with ID: $carfId"
+    )
+
+    EitherT {
+      http
+        .get(baseUrl)
+        .execute[HttpResponse]
+        .map { httpResponse =>
+          httpResponse.status match {
+            case OK        =>
+              Try(httpResponse.json.as[DisplaySubscriptionResponse]) match {
+                case Success(data)      => Right(data)
+                case Failure(exception) =>
+                  logger.warn(s"Error parsing DisplaySubscriptionResponse with endpoint: ${baseUrl.toURI}")
+                  Left(ApiError.JsonValidationError)
+              }
+            case NOT_FOUND =>
+              logger.warn(
+                s"No match could be found for this user: status code: ${httpResponse.status}, from endpoint: ${baseUrl.toURI}"
+              )
+              Left(ApiError.NotFoundError)
+            case _         =>
+              logger.warn(s"Unexpected response: status code: ${httpResponse.status}, from endpoint: ${baseUrl.toURI}")
+              Left(InternalServerError)
+          }
+
         }
     }
   }

--- a/app/controllers/actions/ChangeDetailsDataRequiredAction.scala
+++ b/app/controllers/actions/ChangeDetailsDataRequiredAction.scala
@@ -17,6 +17,7 @@
 package controllers.actions
 
 import controllers.routes
+import models.responses.DisplaySubscriptionResponse
 import models.{DataRequestWithSubscriptionId, IdentifierRequestWithSubscriptionId}
 import play.api.Logging
 import play.api.mvc.Results.Redirect
@@ -45,8 +46,8 @@ class ChangeDetailsDataRequiredActionImpl @Inject() (
     sessionRepository.get(request.userId) flatMap {
       case Some(userAnswers) =>
         if (userAnswers.displaySubscriptionResponse.isEmpty) {
-          subscriptionService.displaySubscription(request.subscriptionId) flatMap {
-            case Some(value) =>
+          subscriptionService.displaySubscription(request.subscriptionId).value.flatMap {
+            case Right(value) =>
               Future.successful(
                 Right(
                   DataRequestWithSubscriptionId(
@@ -57,7 +58,7 @@ class ChangeDetailsDataRequiredActionImpl @Inject() (
                   )
                 )
               )
-            case None        =>
+            case _            =>
               logger.warn(s"[ChangeDetailsDataRequiredAction] Could not retrieve display subscription details.")
               throw new Exception("Could not retrieve subscription details")
           }

--- a/app/controllers/changeContactDetails/ChangeContactDetailsIndexController.scala
+++ b/app/controllers/changeContactDetails/ChangeContactDetailsIndexController.scala
@@ -19,6 +19,7 @@ package controllers.changeContactDetails
 import controllers.actions.*
 import controllers.routes
 import models.UserAnswers
+import models.responses.DisplaySubscriptionResponse
 import pages.changeContactDetails.{ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage}
 import play.api.Logging
 import play.api.i18n.I18nSupport
@@ -41,8 +42,8 @@ class ChangeContactDetailsIndexController @Inject() (
     with Logging {
 
   def onPageLoad(): Action[AnyContent] = carfIdRetrieval().async { implicit request =>
-    subscriptionService.displaySubscription(request.subscriptionId) flatMap {
-      case Some(subscriptionDetails) =>
+    subscriptionService.displaySubscription(request.subscriptionId).value flatMap {
+      case Right(subscriptionDetails) =>
         subscriptionDetails.isIndividualRegistrationType match {
           case Some(true)  =>
             for {
@@ -72,7 +73,7 @@ class ChangeContactDetailsIndexController @Inject() (
             logger.warn(s"[ChangeContactDetailsIndexController] User answers could not be found for request.")
             Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))
         }
-      case None                      =>
+      case _                          =>
         logger.warn(s"[ChangeContactDetailsIndexController] User answers could not be found for request.")
         Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))
     }

--- a/app/models/responses/DisplaySubscriptionResponse.scala
+++ b/app/models/responses/DisplaySubscriptionResponse.scala
@@ -51,6 +51,7 @@ object DisplaySubscriptionSuccess {
 }
 
 case class DisplaySubscriptionDetails(
+    carfReference: String,
     tradingName: Option[String],
     gbUser: Boolean,
     primaryContact: DisplaySubscriptionContact,

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -65,72 +65,13 @@ class SubscriptionService @Inject() (
   def displaySubscription(subscriptionId: SubscriptionId)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext
-  ): Future[Option[DisplaySubscriptionResponse]] =
-    if (subscriptionId.value.take(1) == "9") {
-      Future.successful(None)
-    } else {
-      Future.successful(
-        Some(
-          DisplaySubscriptionResponse(success =
-            DisplaySubscriptionSuccess(
-              processingDate = "test-time",
-              carfSubscriptionDetails = DisplaySubscriptionDetails(
-                tradingName = Some("test-trading-name"),
-                gbUser = true,
-                primaryContact = primaryContactDetail(subscriptionId),
-                secondaryContact = secondaryContactDetail(subscriptionId)
-              )
-            )
-          )
-        )
-      )
-    }
-
-  private def primaryContactDetail(subscriptionId: SubscriptionId): DisplaySubscriptionContact =
-    if (subscriptionId.value.take(1) == "1") {
-      DisplaySubscriptionContact(
-        individual =
-          Some(DisplaySubscriptionIndividual(firstName = "Timmy", middleName = Some("John"), lastName = "Jimmy")),
-        organisation = None,
-        email = "hi@example.com",
-        phone = Some("12345"),
-        mobile = Some("67890")
-      )
-    } else if (subscriptionId.value.take(1) == "2") {
-      DisplaySubscriptionContact(
-        individual =
-          Some(DisplaySubscriptionIndividual(firstName = "Tommy", middleName = Some("Jim"), lastName = "Johnny")),
-        organisation = None,
-        email = "bye@example.com",
-        phone = None,
-        mobile = None
-      )
-    } else {
-      DisplaySubscriptionContact(
-        individual = None,
-        organisation = Some(DisplaySubscriptionOrganisation(name = "ABC Fruit Limited")),
-        email = "hi@example.com",
-        phone = Some("12345"),
-        mobile = Some("67890")
-      )
-    }
-
-  private def secondaryContactDetail(subscriptionId: SubscriptionId): Option[DisplaySubscriptionContact] =
-    if (subscriptionId.value.take(1) == "1") {
-      None
-    } else if (subscriptionId.value.take(1) == "2") {
-      None
-    } else {
-      Some(
-        DisplaySubscriptionContact(
-          individual = None,
-          organisation = Some(DisplaySubscriptionOrganisation(name = "WindsAndWaves.pkmn")),
-          email = "hi@example.com",
-          phone = Some("12345"),
-          mobile = Some("67890")
-        )
-      )
-    }
+  ): ResultT[DisplaySubscriptionResponse] =
+    subscriptionConnector
+      .displaySubscription(subscriptionId.value)
+      .leftMap { error =>
+        logger.error(s"Failed to retrieve subscription: $error")
+        error
+      }
 
   def updateSubscription(subscriptionId: SubscriptionId)(implicit hc: HeaderCarrier): Future[Either[CarfError, Unit]] =
     if (subscriptionId.value.take(3) == "199") {

--- a/it/test/connectors/SubscriptionConnectorISpec.scala
+++ b/it/test/connectors/SubscriptionConnectorISpec.scala
@@ -16,11 +16,14 @@
 
 package connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import itutil.ApplicationWithWiremock
 import models.SubscriptionId
-import models.error.ApiError.{AlreadyRegisteredError, JsonValidationError, UnableToCreateSubscriptionError}
+import models.error.ApiError.{AlreadyRegisteredError, InternalServerError, JsonValidationError, NotFoundError, UnableToCreateSubscriptionError}
 import models.requests.{CreateSubscriptionRequest, SubscriptionContactDetails, SubscriptionIndividualContact, SubscriptionOrganisationContact}
+import models.responses.{DisplaySubscriptionContact, DisplaySubscriptionDetails, DisplaySubscriptionIndividual, DisplaySubscriptionResponse, DisplaySubscriptionSuccess}
+import org.scalactic.Prettifier.default
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import play.api.http.Status.*
@@ -39,6 +42,8 @@ class SubscriptionConnectorISpec
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 
   val connector: SubscriptionConnector = app.injector.instanceOf[SubscriptionConnector]
+
+  val testSubscriptionId: String = "CARF0000000001"
 
   val validContactInformation: SubscriptionContactDetails = SubscriptionContactDetails(
     individual = Some(SubscriptionIndividualContact("John", "Doe")),
@@ -63,7 +68,78 @@ class SubscriptionConnectorISpec
     )
   )
 
+  val testSubscriptionDisplayResponse = DisplaySubscriptionResponse(
+    success = DisplaySubscriptionSuccess(
+      processingDate = "2024-01-25T09:26:17Z",
+      carfSubscriptionDetails = DisplaySubscriptionDetails(
+        carfReference = testSubscriptionId,
+        tradingName = Some("CARF LTD"),
+        gbUser = true,
+        primaryContact = DisplaySubscriptionContact(
+          individual = Some(
+            DisplaySubscriptionIndividual(
+              firstName = "Joe",
+              middleName = None,
+              lastName = "Smith"
+            )
+          ),
+          email = "GroupRep@FATCACRS.com",
+          phone = Some("01232473743"),
+          mobile = Some("07232473743"),
+          organisation = None
+        ),
+        secondaryContact = Some(
+          DisplaySubscriptionContact(
+            individual = Some(
+              DisplaySubscriptionIndividual(
+                firstName = "Joe",
+                middleName = Some("Martyn"),
+                lastName = "Smith"
+              )
+            ),
+            email = "GroupRep@FATCACRS.com",
+            phone = Some("01232473744"),
+            mobile = Some("07232473744"),
+            organisation = None
+          )
+        )
+      )
+    )
+  )
+
   val validSubscriptionResponseJson: String = """{"success":{"CARFReference":"CARF123456"}}"""
+
+  val testDisplaySubscriptionResponseJson: String =
+    """
+      |{
+      |  "success": {
+      |    "processingDate": "2024-01-25T09:26:17Z",
+      |    "carfSubscriptionDetails": {
+      |      "carfReference": "CARF0000000001",
+      |      "tradingName": "CARF LTD",
+      |      "gbUser": true,
+      |      "primaryContact": {
+      |        "individual": {
+      |          "firstName": "Joe",
+      |          "lastName": "Smith"
+      |        },
+      |        "email": "GroupRep@FATCACRS.com",
+      |        "phone": "01232473743",
+      |        "mobile": "07232473743"
+      |      },
+      |      "secondaryContact": {
+      |        "individual": {
+      |          "firstName": "Joe",
+      |          "middleName": "Martyn",
+      |          "lastName": "Smith"
+      |        },
+      |        "email": "GroupRep@FATCACRS.com",
+      |        "phone": "01232473744",
+      |        "mobile": "07232473744"
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
 
   "createSubscription" should {
     "successfully create a subscription and return a subscription ID" in {
@@ -234,6 +310,139 @@ class SubscriptionConnectorISpec
 
       val result = connector.createSubscription(validRequestWithoutSecondaryContact).value.futureValue
       result shouldBe Right(SubscriptionId("CARF123456"))
+    }
+
+  }
+
+  "displaySubscription" should {
+
+    val baseUrlPattern = s"/carf-registration/subscription/display/.*"
+
+    "successfully retrieve a DisplaySubscriptionResponse" in {
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(testDisplaySubscriptionResponseJson)
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Right(testSubscriptionDisplayResponse)
+    }
+
+    "return JsonValidationError when response JSON is invalid" in {
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(Json.toJson("invalid response").toString)
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Left(JsonValidationError)
+    }
+
+    "return JsonValidationError when response JSON structure is incorrect" in {
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody("""{"incorrect": "structure"}""")
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Left(JsonValidationError)
+    }
+
+    "return NotFoundError when backend returns 404" in {
+      val errorResponse = Json.obj(
+        "status"  -> "Not Found",
+        "message" -> "Not Found"
+      )
+
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(NOT_FOUND)
+              .withBody(errorResponse.toString)
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Left(NotFoundError)
+    }
+
+    "return InternalServerError when backend returns 400" in {
+      val errorResponse = Json.obj(
+        "status"  -> "Bad request",
+        "message" -> "Invalid request"
+      )
+
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(BAD_REQUEST)
+              .withBody(errorResponse.toString)
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Left(InternalServerError)
+    }
+
+    "return InternalServerError when backend returns 422" in {
+      val errorResponse = Json.obj(
+        "status"  -> "Unprocessable Entity",
+        "message" -> "Invalid ID"
+      )
+
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(UNPROCESSABLE_ENTITY)
+              .withBody(errorResponse.toString)
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Left(InternalServerError)
+    }
+
+    "return InternalServerError when backend returns 500" in {
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(INTERNAL_SERVER_ERROR)
+              .withBody(Json.obj("message" -> "Internal server error").toString)
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Left(InternalServerError)
+    }
+
+    "return InternalServerError when backend returns 503" in {
+      stubFor(
+        get(urlPathMatching(baseUrlPattern))
+          .willReturn(
+            aResponse()
+              .withStatus(SERVICE_UNAVAILABLE)
+              .withBody(Json.obj("message" -> "Service unavailable").toString)
+          )
+      )
+
+      val result = connector.displaySubscription(testSubscriptionId).value.futureValue
+      result shouldBe Left(InternalServerError)
     }
 
   }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -63,7 +63,7 @@ trait SpecBase
   val testUtr: UniqueTaxpayerReference   = UniqueTaxpayerReference("1234567890")
   val testUtrString: String              = testUtr.uniqueTaxPayerReference
   val testInternalId: String             = "12345"
-  val testSubscriptionId: SubscriptionId = SubscriptionId("67890")
+  val testSubscriptionId: SubscriptionId = SubscriptionId("CARF0000000001")
   val testSafeId: String                 = "XE0000123456789"
 
   private val UtcZoneId          = "UTC"
@@ -164,6 +164,7 @@ trait SpecBase
     DisplaySubscriptionSuccess(
       processingDate = LocalDate.now().toString,
       carfSubscriptionDetails = DisplaySubscriptionDetails(
+        carfReference = testSubscriptionId.value,
         tradingName = Some("testTradingName"),
         gbUser = true,
         primaryContact = DisplaySubscriptionContact(
@@ -183,6 +184,7 @@ trait SpecBase
     DisplaySubscriptionSuccess(
       processingDate = LocalDate.now().toString,
       carfSubscriptionDetails = DisplaySubscriptionDetails(
+        carfReference = testSubscriptionId.value,
         tradingName = Some("testTradingName"),
         gbUser = true,
         primaryContact = DisplaySubscriptionContact(
@@ -201,6 +203,7 @@ trait SpecBase
     DisplaySubscriptionSuccess(
       processingDate = LocalDate.now().toString,
       carfSubscriptionDetails = DisplaySubscriptionDetails(
+        carfReference = testSubscriptionId.value,
         tradingName = Some("testTradingName"),
         gbUser = true,
         primaryContact = DisplaySubscriptionContact(
@@ -220,6 +223,7 @@ trait SpecBase
     DisplaySubscriptionSuccess(
       processingDate = LocalDate.now().toString,
       carfSubscriptionDetails = DisplaySubscriptionDetails(
+        carfReference = testSubscriptionId.value,
         tradingName = Some("testTradingName"),
         gbUser = true,
         primaryContact = DisplaySubscriptionContact(

--- a/test/controllers/actions/ChangeDetailsDataRequiredActionSpec.scala
+++ b/test/controllers/actions/ChangeDetailsDataRequiredActionSpec.scala
@@ -17,7 +17,9 @@
 package controllers.actions
 
 import base.SpecBase
+import cats.data.EitherT
 import controllers.routes
+import models.error.ApiError
 import models.{DataRequestWithSubscriptionId, IdentifierRequestWithSubscriptionId}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -119,9 +121,7 @@ class ChangeDetailsDataRequiredActionSpec extends SpecBase {
       )
 
       when(mockSubscriptionService.displaySubscription(any())(any(), any())).thenReturn(
-        Future.successful(
-          Some(testIndividualDisplaySubscriptionResponse(hasPhone = true))
-        )
+        EitherT.rightT[Future, ApiError](testIndividualDisplaySubscriptionResponse(hasPhone = true))
       )
 
       val result =

--- a/test/controllers/changeContactDetails/ChangeContactDetailsIndexControllerSpec.scala
+++ b/test/controllers/changeContactDetails/ChangeContactDetailsIndexControllerSpec.scala
@@ -17,6 +17,10 @@
 package controllers.changeContactDetails
 
 import base.SpecBase
+import cats.data.EitherT
+import models.error.ApiError
+import models.error.ApiError.InternalServerError
+import models.responses.DisplaySubscriptionResponse
 import models.{UniqueTaxpayerReference, UserAnswers}
 import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.Mockito.{times, verify, when}
@@ -42,7 +46,8 @@ class ChangeContactDetailsIndexControllerSpec extends SpecBase {
   "Change Contact Details Index Controller" - {
     "when the service call to the get the display subscription details returns none" - {
       "must redirect to the journey recovery page" in new Setup {
-        when(mockSubscriptionService.displaySubscription(any())(any(), any())).thenReturn(Future.successful(None))
+        when(mockSubscriptionService.displaySubscription(any())(any(), any()))
+          .thenReturn(EitherT.leftT[Future, DisplaySubscriptionResponse](InternalServerError))
 
         val request = FakeRequest(GET, routes.ChangeContactDetailsIndexController.onPageLoad().url)
 
@@ -56,7 +61,7 @@ class ChangeContactDetailsIndexControllerSpec extends SpecBase {
     "when display subscription response is organisation" - {
       "must redirect user to the placeholder controller" in new Setup {
         when(mockSubscriptionService.displaySubscription(any())(any(), any()))
-          .thenReturn(Future.successful(Some(testOrganisationDisplaySubscriptionResponse)))
+          .thenReturn(EitherT.rightT[Future, ApiError](testOrganisationDisplaySubscriptionResponse))
 
         val request = FakeRequest(GET, routes.ChangeContactDetailsIndexController.onPageLoad().url)
 
@@ -76,7 +81,7 @@ class ChangeContactDetailsIndexControllerSpec extends SpecBase {
     "when display subscription response is of type none" - {
       "must redirect user to journey recovery" in new Setup {
         when(mockSubscriptionService.displaySubscription(any())(any(), any()))
-          .thenReturn(Future.successful(Some(testInvalidDisplaySubscriptionResponse)))
+          .thenReturn(EitherT.rightT[Future, ApiError](testInvalidDisplaySubscriptionResponse))
 
         val request = FakeRequest(GET, routes.ChangeContactDetailsIndexController.onPageLoad().url)
 
@@ -90,7 +95,7 @@ class ChangeContactDetailsIndexControllerSpec extends SpecBase {
     "when display subscription response is individual" - {
       "must set user answers with all page info and redirect successfully when phone is none" in new Setup {
         when(mockSubscriptionService.displaySubscription(any())(any(), any()))
-          .thenReturn(Future.successful(Some(testIndividualDisplaySubscriptionResponse(hasPhone = false))))
+          .thenReturn(EitherT.rightT[Future, ApiError](testIndividualDisplaySubscriptionResponse(hasPhone = false)))
         when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
 
         val request = FakeRequest(GET, routes.ChangeContactDetailsIndexController.onPageLoad().url)
@@ -110,7 +115,7 @@ class ChangeContactDetailsIndexControllerSpec extends SpecBase {
       }
       "must set user answers with all page info and redirect successfully when phone is returned from the service" in new Setup {
         when(mockSubscriptionService.displaySubscription(any())(any(), any()))
-          .thenReturn(Future.successful(Some(testIndividualDisplaySubscriptionResponse(hasPhone = true))))
+          .thenReturn(EitherT.rightT[Future, ApiError](testIndividualDisplaySubscriptionResponse(hasPhone = true)))
         when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
 
         val request = FakeRequest(GET, routes.ChangeContactDetailsIndexController.onPageLoad().url)

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -23,6 +23,7 @@ import models.*
 import models.error.ApiError
 import models.error.ApiError.{InternalServerError, MandatoryInformationMissingError}
 import models.requests.CreateSubscriptionRequest
+import models.responses.{DisplaySubscriptionContact, DisplaySubscriptionDetails, DisplaySubscriptionIndividual, DisplaySubscriptionResponse, DisplaySubscriptionSuccess}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, reset, verify, when}
 import pages.individual.{IndividualEmailPage, IndividualHavePhonePage, IndividualPhoneNumberPage, WhatIsYourNameIndividualPage}
@@ -53,6 +54,45 @@ class SubscriptionServiceSpec extends SpecBase {
     .set(IndividualPhoneNumberPage, "01234567890")
     .success
     .value
+
+  val exampleSubscriptionDisplayResponse = DisplaySubscriptionResponse(
+    success = DisplaySubscriptionSuccess(
+      processingDate = "2024-01-25T09:26:17Z",
+      carfSubscriptionDetails = DisplaySubscriptionDetails(
+        carfReference = exampleSubscriptionId.value,
+        tradingName = Some("CARF LTD"),
+        gbUser = true,
+        primaryContact = DisplaySubscriptionContact(
+          individual = Some(
+            DisplaySubscriptionIndividual(
+              firstName = "Joe",
+              middleName = None,
+              lastName = "Smith"
+            )
+          ),
+          email = "GroupRep@FATCACRS.com",
+          phone = Some("01232473743"),
+          mobile = Some("07232473743"),
+          organisation = None
+        ),
+        secondaryContact = Some(
+          DisplaySubscriptionContact(
+            individual = Some(
+              DisplaySubscriptionIndividual(
+                firstName = "Joe",
+                middleName = Some("Martyn"),
+                lastName = "Smith"
+              )
+            ),
+            email = "GroupRep@FATCACRS.com",
+            phone = Some("01232473744"),
+            mobile = Some("07232473744"),
+            organisation = None
+          )
+        )
+      )
+    )
+  )
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -90,6 +130,30 @@ class SubscriptionServiceSpec extends SpecBase {
         )
         verify(mockConnector, never()).createSubscription(any[CreateSubscriptionRequest])(any(), any())
       }
+    }
+
+    "displaySubscription" - {
+      "should successfully display subscription with valid subscription id" in {
+        when(mockConnector.displaySubscription(any[String])(any(), any())).thenReturn(
+          EitherT.rightT[Future, ApiError](exampleSubscriptionDisplayResponse)
+        )
+
+        val result = testService.displaySubscription(exampleSubscriptionId).value.futureValue
+
+        result mustBe Right(exampleSubscriptionDisplayResponse)
+        verify(mockConnector).displaySubscription(any[String])(any(), any())
+      }
+
+      "should return error when connector fails" in {
+        when(mockConnector.displaySubscription(any[String])(any(), any())).thenReturn(
+          EitherT.leftT[Future, SubscriptionId](InternalServerError)
+        )
+
+        val result = testService.displaySubscription(exampleSubscriptionId).value.futureValue
+
+        result mustBe Left(InternalServerError)
+      }
+
     }
   }
 }


### PR DESCRIPTION
Changes made in this ticket directly affect how we stub data for the `ChangeContactDetailsPage`, as originally setup in #108 

The new data for the `displaySubscription` API call and expected responses are as follows:
Data setup:
- Affinity Group: Individual/Organisation
- Enrolment Key: HMRC-CARF-ORG
- Identifier Name: CARFID
- Identifier Value:

1. ID starts with "Y" - Internal Server Error (500)
2. ID starts with "X" - Not Found Error (404)
3. ID starts with "W" - Success with individual contact details (all optional fields empty) 
4. ID starts with "T" - Bad Request Error (400)
5. ID starts with "S" - Service Unavailable Error (503)
6. ID starts with "R" - Success with organisation contact details (all fields populated)
7. ID starts with "P" - Unprocessable Entity Error (422)
8. ID starts with "O" - Success with no phone
9. ID starts with anything else - Success with individual contact details (all fields populated)

All values are case insensitive.

Any previous stubbed data options for the `displaySubscription` API call are no longer available.