### PR TITLE
CARF-190: Organisation - What is the name of the person or team we should contact?

### DIFF
--- a/app/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactNameController.scala
+++ b/app/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactNameController.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import controllers.actions.*
+import models.Mode
+import navigation.Navigator
+import pages.changeContactDetails.ChangeDetailsOrganisationSecondContactNamePage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.ChangeDetailsOrganisationSecondContactNameView
+import forms.organisation.OrganisationSecondContactNameFormProvider
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class ChangeDetailsOrganisationSecondContactNameController @Inject() (
+    override val messagesApi: MessagesApi,
+    sessionRepository: SessionRepository,
+    navigator: Navigator,
+    carfIdRetrieval: CarfIdRetrievalAction,
+    changeDetailsDataRequiredAction: ChangeDetailsDataRequiredAction,
+    formProvider: OrganisationSecondContactNameFormProvider,
+    val controllerComponents: MessagesControllerComponents,
+    view: ChangeDetailsOrganisationSecondContactNameView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] =
+    (carfIdRetrieval() andThen changeDetailsDataRequiredAction) { implicit request =>
+
+      val preparedForm = request.userAnswers.get(ChangeDetailsOrganisationSecondContactNamePage).fold(form)(form.fill)
+
+      Ok(view(preparedForm, mode))
+    }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (carfIdRetrieval() andThen changeDetailsDataRequiredAction).async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <-
+                Future.fromTry(request.userAnswers.set(ChangeDetailsOrganisationSecondContactNamePage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(ChangeDetailsOrganisationSecondContactNamePage, mode, updatedAnswers))
+        )
+  }
+}

--- a/app/navigation/NormalRoutesNavigator.scala
+++ b/app/navigation/NormalRoutesNavigator.scala
@@ -165,6 +165,12 @@ trait NormalRoutesNavigator extends UserAnswersHelper with Logging {
           "Should redirect to change-contact/organisation/details page (CARF-141)"
         )
 
+    case ChangeDetailsOrganisationSecondContactNamePage =>
+      _ =>
+        routes.PlaceholderController.onPageLoad(
+          "Should redirect to change-contact/organisation/details page (CARF-141)"
+        )
+
     case _ =>
       _ => routes.JourneyRecoveryController.onPageLoad()
   }

--- a/app/pages/changeContactDetails/ChangeDetailsOrganisationSecondContactNamePage.scala
+++ b/app/pages/changeContactDetails/ChangeDetailsOrganisationSecondContactNamePage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object ChangeDetailsOrganisationSecondContactNamePage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "changeDetailsOrganisationSecondContactName"
+}

--- a/app/views/ChangeDetailsOrganisationSecondContactNameView.scala.html
+++ b/app/views/ChangeDetailsOrganisationSecondContactNameView.scala.html
@@ -1,0 +1,51 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputWidth._
+
+@this(
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("organisationSecondContactName.title"))) {
+
+    @formHelper(action = controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactNameController.onSubmit()) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("organisationSecondContactName.heading")).asPageHeading()
+            )
+            .withHint(HintViewModel(HtmlContent(messages("organisationSecondContactName.hint"))))
+            .withWidth(ThreeQuarters)
+            .withAutocomplete("name")
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue")).withAttribute("id" -> "continue")
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -258,3 +258,6 @@ POST        /change-contact/organisation/contact-name                           
 
 GET         /change-contact/organisation/email                                  controllers.changeContactDetails.ChangeDetailsFirstContactEmailController.onPageLoad(mode: Mode = NormalMode)
 POST        /change-contact/organisation/email                                  controllers.changeContactDetails.ChangeDetailsFirstContactEmailController.onSubmit(mode: Mode = NormalMode)
+
+GET         /change-contact/organisation/second-contact-name                    controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactNameController.onPageLoad(mode: Mode = NormalMode)
+POST        /change-contact/organisation/second-contact-name                    controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactNameController.onSubmit(mode: Mode = NormalMode)

--- a/test/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactNameControllerSpec.scala
+++ b/test/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactNameControllerSpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import base.SpecBase
+import forms.organisation.OrganisationSecondContactNameFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.changeContactDetails.ChangeDetailsOrganisationSecondContactNamePage
+import play.api.data.Form
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import repositories.SessionRepository
+import views.html.ChangeDetailsOrganisationSecondContactNameView
+
+import scala.concurrent.Future
+
+class ChangeDetailsOrganisationSecondContactNameControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider: OrganisationSecondContactNameFormProvider = new OrganisationSecondContactNameFormProvider()
+  val form: Form[String]                                      = formProvider()
+
+  lazy val changeDetailsOrganisationSecondContactNameRoute =
+    controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactNameController
+      .onPageLoad()
+      .url
+
+  "ChangeDetailsOrganisationSecondContactName Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, changeDetailsOrganisationSecondContactNameRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ChangeDetailsOrganisationSecondContactNameView]
+
+        status(result)          mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers =
+        UserAnswers(userAnswersId).set(ChangeDetailsOrganisationSecondContactNamePage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, changeDetailsOrganisationSecondContactNameRoute)
+
+        val view = application.injector.instanceOf[ChangeDetailsOrganisationSecondContactNameView]
+
+        val result = route(application, request).value
+
+        status(result)          mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, changeDetailsOrganisationSecondContactNameRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, changeDetailsOrganisationSecondContactNameRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[ChangeDetailsOrganisationSecondContactNameView]
+
+        val result = route(application, request).value
+
+        status(result)          mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, changeDetailsOrganisationSecondContactNameRoute)
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, changeDetailsOrganisationSecondContactNameRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/navigation/NormalRoutesNavigatorSpec.scala
+++ b/test/navigation/NormalRoutesNavigatorSpec.scala
@@ -26,7 +26,7 @@ import models.countries.*
 import models.responses.AddressRegistrationResponse
 import org.scalactic.Prettifier.default
 import pages.*
-import pages.changeContactDetails.{ChangeDetailsFirstContactEmailPage, ChangeDetailsFirstContactNamePage, ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage}
+import pages.changeContactDetails.{ChangeDetailsFirstContactEmailPage, ChangeDetailsFirstContactNamePage, ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage, ChangeDetailsOrganisationSecondContactNamePage}
 import pages.individual.*
 import pages.individualWithoutId.*
 import pages.orgWithoutId.{HaveTradingNamePage, OrgWithoutIdBusinessNamePage, OrganisationBusinessAddressPage}
@@ -1271,6 +1271,21 @@ class NormalRoutesNavigatorSpec extends SpecBase {
 
         navigator.nextPage(
           ChangeDetailsFirstContactEmailPage,
+          NormalMode,
+          userAnswers
+        ) mustBe routes.PlaceholderController.onPageLoad(
+          "Should redirect to change-contact/organisation/details page (CARF-141)"
+        )
+      }
+    }
+
+    "ChangeDetailsOrganisationSecondContactNamePage navigation" - {
+      "must navigate from ChangeDetailsOrganisationSecondContactNamePage to ChangeOrganisationContactDetailsController" in {
+        val userAnswers = UserAnswers(userAnswersId)
+          .withPage(ChangeDetailsOrganisationSecondContactNamePage, "Prof. Birch")
+
+        navigator.nextPage(
+          ChangeDetailsOrganisationSecondContactNamePage,
           NormalMode,
           userAnswers
         ) mustBe routes.PlaceholderController.onPageLoad(


### PR DESCRIPTION
- Added `ChangeDetailsOrganisationSecondContactName` page
- Added navigation
- Added relevant tests

For testing:
- Login with [change-contact authorisation wizard](http://localhost:9949/auth-login-stub/gg-sign-in?continue=http://localhost:17000/register-for-cryptoasset-reporting/change-contact) using a valid CARF-ID
- Manually change the url to /change-contact/organisation/second-contact-name