### PR TITLE
CARF-191: Organisation - What is the email address for [second contact name]?

### DIFF
--- a/app/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailController.scala
+++ b/app/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailController.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import controllers.actions.*
+import models.Mode
+import navigation.Navigator
+import pages.changeContactDetails.{ChangeDetailsOrganisationSecondContactEmailPage, ChangeDetailsOrganisationSecondContactNamePage}
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.ChangeDetailsOrganisationSecondContactEmailView
+import forms.organisation.OrganisationSecondContactEmailFormProvider
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class ChangeDetailsOrganisationSecondContactEmailController @Inject() (
+    override val messagesApi: MessagesApi,
+    sessionRepository: SessionRepository,
+    navigator: Navigator,
+    carfIdRetrieval: CarfIdRetrievalAction,
+    changeDetailsDataRequiredAction: ChangeDetailsDataRequiredAction,
+    formProvider: OrganisationSecondContactEmailFormProvider,
+    val controllerComponents: MessagesControllerComponents,
+    view: ChangeDetailsOrganisationSecondContactEmailView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
+
+  val form: Form[String] = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] =
+    (carfIdRetrieval() andThen changeDetailsDataRequiredAction) { implicit request =>
+
+      val preparedForm = request.userAnswers.get(ChangeDetailsOrganisationSecondContactEmailPage).fold(form)(form.fill)
+
+      request.userAnswers
+        .get(ChangeDetailsOrganisationSecondContactNamePage)
+        .fold(Redirect(controllers.changeContactDetails.routes.ContactDetailsMissingController.onPageLoad()))(name =>
+          Ok(view(preparedForm, mode, name))
+        )
+    }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (carfIdRetrieval() andThen changeDetailsDataRequiredAction).async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors =>
+            Future.successful(
+              request.userAnswers
+                .get(ChangeDetailsOrganisationSecondContactNamePage)
+                .fold(Redirect(controllers.changeContactDetails.routes.ContactDetailsMissingController.onPageLoad()))(
+                  name => BadRequest(view(formWithErrors, mode, name))
+                )
+            ),
+          value =>
+            for {
+              updatedAnswers <-
+                Future.fromTry(request.userAnswers.set(ChangeDetailsOrganisationSecondContactEmailPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(ChangeDetailsOrganisationSecondContactEmailPage, mode, updatedAnswers))
+        )
+  }
+}

--- a/app/navigation/NormalRoutesNavigator.scala
+++ b/app/navigation/NormalRoutesNavigator.scala
@@ -165,6 +165,12 @@ trait NormalRoutesNavigator extends UserAnswersHelper with Logging {
           "Should redirect to change-contact/organisation/details page (CARF-141)"
         )
 
+    case ChangeDetailsOrganisationSecondContactEmailPage =>
+      _ =>
+        routes.PlaceholderController.onPageLoad(
+          "Should redirect to change-contact/organisation/details page (CARF-141)"
+        )
+
     case _ =>
       _ => routes.JourneyRecoveryController.onPageLoad()
   }

--- a/app/navigation/ProvideRoutesNavigator.scala
+++ b/app/navigation/ProvideRoutesNavigator.scala
@@ -23,7 +23,7 @@ import models.JourneyType.{IndWithNino, IndWithUtr, IndWithoutId, OrgWithUtr, Or
 import models.RegistrationType.{Individual, SoleTrader}
 import models.{NormalMode, ProvideMode, RegistrationType, UserAnswers}
 import pages.*
-import pages.changeContactDetails.{ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage}
+import pages.changeContactDetails.{ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage, ChangeDetailsOrganisationSecondContactEmailPage}
 import pages.organisation.{HaveUTRPage, NavigatorOnlyIndividualRegistrationTypePage, RegistrationTypePage}
 import play.api.Logging
 import play.api.mvc.Call
@@ -43,6 +43,12 @@ trait ProvideRoutesNavigator extends UserAnswersHelper with Logging {
 
     case ChangeDetailsIndividualPhoneNumberPage =>
       _ => changeDetailsRoutes.ChangeIndividualContactDetailsController.onPageLoad()
+
+    case ChangeDetailsOrganisationSecondContactEmailPage =>
+      _ =>
+        routes.PlaceholderController.onPageLoad(
+          "Should redirect to change-contact/organisation/second-contact-have-phone page (CARF-192)"
+        )
 
     case _ =>
       _ => routes.JourneyRecoveryController.onPageLoad()

--- a/app/pages/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailPage.scala
+++ b/app/pages/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object ChangeDetailsOrganisationSecondContactEmailPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "changeDetailsOrganisationSecondContactEmail"
+}

--- a/app/pages/changeContactDetails/ChangeDetailsOrganisationSecondContactNamePage.scala
+++ b/app/pages/changeContactDetails/ChangeDetailsOrganisationSecondContactNamePage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object ChangeDetailsOrganisationSecondContactNamePage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "changeDetailsOrganisationSecondContactName"
+}

--- a/app/views/ChangeDetailsOrganisationSecondContactEmailView.scala.html
+++ b/app/views/ChangeDetailsOrganisationSecondContactEmailView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("organisationSecondContactEmail.title"))) {
 
-    @formHelper(action = controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactEmailController.onSubmit()) {
+    @formHelper(action = controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactEmailController.onSubmit(mode)) {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/ChangeDetailsOrganisationSecondContactEmailView.scala.html
+++ b/app/views/ChangeDetailsOrganisationSecondContactEmailView.scala.html
@@ -1,0 +1,54 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputWidth._
+
+@this(
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode, secondContactName: String)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("organisationSecondContactEmail.title"))) {
+
+    @formHelper(action = controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactEmailController.onSubmit()) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        <h1 class="govuk-heading-l long-word">@messages("organisationSecondContactEmail.heading", secondContactName)</h1>
+
+        <p class="govuk-body">@messages("firstContactEmail.paragraph")</p>
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("organisationSecondContactEmail.heading", secondContactName)).withCssClass("govuk-visually-hidden")
+            )
+            .withWidth(Full)
+            .asEmail()
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue")).withAttribute("id" -> "continue")
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -258,3 +258,6 @@ POST        /change-contact/organisation/contact-name                           
 
 GET         /change-contact/organisation/email                                  controllers.changeContactDetails.ChangeDetailsFirstContactEmailController.onPageLoad(mode: Mode = NormalMode)
 POST        /change-contact/organisation/email                                  controllers.changeContactDetails.ChangeDetailsFirstContactEmailController.onSubmit(mode: Mode = NormalMode)
+
+GET         /change-contact/organisation/second-contact-email                   controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactEmailController.onPageLoad(mode: Mode = NormalMode)
+POST        /change-contact/organisation/second-contact-email                   controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactEmailController.onSubmit(mode: Mode = NormalMode)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -261,3 +261,5 @@ POST        /change-contact/organisation/email                                  
 
 GET         /change-contact/organisation/second-contact-email                   controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactEmailController.onPageLoad(mode: Mode = NormalMode)
 POST        /change-contact/organisation/second-contact-email                   controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactEmailController.onSubmit(mode: Mode = NormalMode)
+GET         /change-contact/organisation/provide-second-contact-email           controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactEmailController.onPageLoad(mode: Mode = ProvideMode)
+POST        /change-contact/organisation/provide-second-contact-email           controllers.changeContactDetails.ChangeDetailsOrganisationSecondContactEmailController.onSubmit(mode: Mode = ProvideMode)

--- a/test/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailControllerSpec.scala
+++ b/test/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailControllerSpec.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import base.SpecBase
+import controllers.routes
+import forms.organisation.OrganisationSecondContactEmailFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.changeContactDetails.{ChangeDetailsOrganisationSecondContactEmailPage, ChangeDetailsOrganisationSecondContactNamePage}
+import play.api.data.Form
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import views.html.ChangeDetailsOrganisationSecondContactEmailView
+
+import scala.concurrent.Future
+
+class ChangeDetailsOrganisationSecondContactEmailControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider: OrganisationSecondContactEmailFormProvider = new OrganisationSecondContactEmailFormProvider()
+  val form: Form[String]                                       = formProvider()
+
+  val contactName: String  = "Prof. Rowan"
+  val exampleEmail: String = "prof.rowan@email.com"
+
+  lazy val changeDetailsOrganisationSecondContactEmailRoute =
+    controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactEmailController.onPageLoad().url
+
+  "ChangeDetailsOrganisationSecondContactEmail Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .withPage(ChangeDetailsOrganisationSecondContactNamePage, contactName)
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, changeDetailsOrganisationSecondContactEmailRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ChangeDetailsOrganisationSecondContactEmailView]
+
+        status(result)          mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode, contactName)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .withPage(ChangeDetailsOrganisationSecondContactNamePage, contactName)
+        .withPage(ChangeDetailsOrganisationSecondContactEmailPage, exampleEmail)
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, changeDetailsOrganisationSecondContactEmailRoute)
+
+        val view = application.injector.instanceOf[ChangeDetailsOrganisationSecondContactEmailView]
+
+        val result = route(application, request).value
+
+        status(result)          mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(exampleEmail), NormalMode, contactName)(
+          request,
+          messages(application)
+        ).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, changeDetailsOrganisationSecondContactEmailRoute)
+            .withFormUrlEncodedBody(("value", exampleEmail))
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .withPage(ChangeDetailsOrganisationSecondContactNamePage, contactName)
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, changeDetailsOrganisationSecondContactEmailRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[ChangeDetailsOrganisationSecondContactEmailView]
+
+        val result = route(application, request).value
+
+        status(result)          mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode, contactName)(
+          request,
+          messages(application)
+        ).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, changeDetailsOrganisationSecondContactEmailRoute)
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Contact Details Missing for a GET if no first contact name is found" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .set(ChangeDetailsOrganisationSecondContactEmailPage, "test@example.com")
+        .success
+        .value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(GET, changeDetailsOrganisationSecondContactEmailRoute)
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.changeContactDetails.routes.ContactDetailsMissingController
+          .onPageLoad()
+          .url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, changeDetailsOrganisationSecondContactEmailRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Contact Details Missing for a POST if no firstContactName is found" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, changeDetailsOrganisationSecondContactEmailRoute)
+            .withFormUrlEncodedBody(("value", "email.com"))
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.changeContactDetails.routes.ContactDetailsMissingController
+          .onPageLoad()
+          .url
+      }
+    }
+  }
+}

--- a/test/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailControllerSpec.scala
+++ b/test/controllers/changeContactDetails/ChangeDetailsOrganisationSecondContactEmailControllerSpec.scala
@@ -45,7 +45,9 @@ class ChangeDetailsOrganisationSecondContactEmailControllerSpec extends SpecBase
   val exampleEmail: String = "prof.rowan@email.com"
 
   lazy val changeDetailsOrganisationSecondContactEmailRoute =
-    controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactEmailController.onPageLoad().url
+    controllers.changeContactDetails.routes.ChangeDetailsOrganisationSecondContactEmailController
+      .onPageLoad(NormalMode)
+      .url
 
   "ChangeDetailsOrganisationSecondContactEmail Controller" - {
 

--- a/test/navigation/NormalRoutesNavigatorSpec.scala
+++ b/test/navigation/NormalRoutesNavigatorSpec.scala
@@ -26,7 +26,7 @@ import models.countries.*
 import models.responses.AddressRegistrationResponse
 import org.scalactic.Prettifier.default
 import pages.*
-import pages.changeContactDetails.{ChangeDetailsFirstContactEmailPage, ChangeDetailsFirstContactNamePage, ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage}
+import pages.changeContactDetails.{ChangeDetailsFirstContactEmailPage, ChangeDetailsFirstContactNamePage, ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage, ChangeDetailsOrganisationSecondContactEmailPage}
 import pages.individual.*
 import pages.individualWithoutId.*
 import pages.orgWithoutId.{HaveTradingNamePage, OrgWithoutIdBusinessNamePage, OrganisationBusinessAddressPage}
@@ -1271,6 +1271,21 @@ class NormalRoutesNavigatorSpec extends SpecBase {
 
         navigator.nextPage(
           ChangeDetailsFirstContactEmailPage,
+          NormalMode,
+          userAnswers
+        ) mustBe routes.PlaceholderController.onPageLoad(
+          "Should redirect to change-contact/organisation/details page (CARF-141)"
+        )
+      }
+    }
+
+    "ChangeDetailsOrganisationSecondContactEmailPage navigation" - {
+      "must navigate from ChangeDetailsOrganisationSecondContactEmailPage to ChangeOrganisationContactDetailsController" in {
+        val userAnswers = UserAnswers(userAnswersId)
+          .withPage(ChangeDetailsOrganisationSecondContactEmailPage, "prof.rowan@email.com")
+
+        navigator.nextPage(
+          ChangeDetailsOrganisationSecondContactEmailPage,
           NormalMode,
           userAnswers
         ) mustBe routes.PlaceholderController.onPageLoad(

--- a/test/navigation/ProvideRoutesNavigatorSpec.scala
+++ b/test/navigation/ProvideRoutesNavigatorSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.changeContactDetails.routes as changeDetailsRoutes
 import controllers.routes
 import models.{ProvideMode, UserAnswers}
-import pages.changeContactDetails.{ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage}
+import pages.changeContactDetails.{ChangeDetailsIndividualEmailPage, ChangeDetailsIndividualHavePhonePage, ChangeDetailsIndividualPhoneNumberPage, ChangeDetailsOrganisationSecondContactEmailPage}
 import pages.individual.HaveNiNumberPage
 
 class ProvideRoutesNavigatorSpec extends SpecBase {
@@ -94,6 +94,23 @@ class ProvideRoutesNavigatorSpec extends SpecBase {
           ProvideMode,
           userAnswers
         ) mustBe changeDetailsRoutes.ChangeIndividualContactDetailsController.onPageLoad()
+      }
+    }
+
+    "when on ChangeDetailsOrganisationSecondContactEmailPage" - {
+      "must navigate to ChangeDetailsOrganisationSecondContactHavePhoneController in ProvideMode" in {
+        val userAnswers = emptyUserAnswers
+          .set(ChangeDetailsOrganisationSecondContactEmailPage, "test@example.com")
+          .success
+          .value
+
+        navigator.nextPage(
+          ChangeDetailsOrganisationSecondContactEmailPage,
+          ProvideMode,
+          userAnswers
+        ) mustBe routes.PlaceholderController.onPageLoad(
+          "Should redirect to change-contact/organisation/second-contact-have-phone page (CARF-192)"
+        )
       }
     }
 


### PR DESCRIPTION
- Added `ChangeDetailsOrganisationSecondContactEmail` page
- Added navigation
- Added relevant tests

For testing:
- Login with [change-contact authorisation wizard](http://localhost:9949/auth-login-stub/gg-sign-in?continue=http://localhost:17000/register-for-cryptoasset-reporting/change-contact) using a valid CARF-ID
- Manually change the url to /change-contact/organisation/second-contact-name
- Populate field and click continue
- Manually change the url to /change-contact/organisation/second-contact-email

If testing scenario where no contact name is present, skip 2nd and 3rd step.
