### PR TITLE
[CARF-412] Implement Update subscription connector and test-only page

### DIFF
--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -20,9 +20,9 @@ import cats.data.EitherT
 import config.FrontendAppConfig
 import models.SubscriptionId
 import models.error.ApiError
-import models.error.ApiError.{AlreadyRegisteredError, InternalServerError, UnableToCreateSubscriptionError}
-import models.requests.CreateSubscriptionRequest
-import models.responses.{CreateSubscriptionResponse, DisplaySubscriptionResponse}
+import models.error.ApiError.{AlreadyRegisteredError, InternalServerError, UnableToProcessSubscriptionError}
+import models.requests.SubscriptionRequest
+import models.responses.{DisplaySubscriptionResponse, SubscriptionResponse}
 import play.api.Logging
 import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.libs.json.Json
@@ -32,6 +32,7 @@ import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
+import java.net.URL
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
@@ -40,26 +41,51 @@ import scala.util.{Failure, Success, Try}
 class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: HttpClientV2) extends Logging {
 
   def createSubscription(
-      createSubscriptionRequest: CreateSubscriptionRequest
+      createSubscriptionRequest: SubscriptionRequest
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): ResultT[SubscriptionId] = {
 
     val submissionUrl = url"${config.carfRegistrationBaseUrl}/subscription/subscribe"
 
+    processSubscriptionRequest(createSubscriptionRequest, submissionUrl, false)
+  }
+
+  def updateSubscription(
+      updateSubscriptionRequest: SubscriptionRequest
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): ResultT[SubscriptionId] = {
+
+    val submissionUrl = url"${config.carfRegistrationBaseUrl}/subscription/amend"
+
+    processSubscriptionRequest(updateSubscriptionRequest, submissionUrl, true)
+  }
+
+  private def processSubscriptionRequest(request: SubscriptionRequest, submissionUrl: URL, isUpdate: Boolean)(implicit
+      hc: HeaderCarrier,
+      ec: ExecutionContext
+  ): ResultT[SubscriptionId] = {
+
+    val action = if isUpdate then "Updating" else "Creating"
+
+    val requestBuilder =
+      if (isUpdate) {
+        http.put(submissionUrl)
+      } else {
+        http.post(submissionUrl)
+      }
+
     logger.debug(
-      s"[SubscriptionConnector] Creating subscription with request:\n ${Json.prettyPrint(Json.toJson(createSubscriptionRequest))}"
+      s"[SubscriptionConnector] $action subscription with request:\n ${Json.prettyPrint(Json.toJson(request))}"
     )
 
     ResultT.fromFuture(
-      http
-        .post(submissionUrl)
-        .withBody(Json.toJson(createSubscriptionRequest))
+      requestBuilder
+        .withBody(Json.toJson(request))
         .execute[HttpResponse]
         .map {
           case response if response.status == OK =>
-            Try(response.json.as[CreateSubscriptionResponse]) match {
+            Try(response.json.as[SubscriptionResponse]) match {
               case Success(data)      => Right(data.subscriptionId)
               case Failure(exception) =>
-                logger.warn(s"Error parsing CreateSubscriptionResponse with endpoint: $submissionUrl")
+                logger.warn(s"Error parsing SubscriptionResponse with endpoint: $submissionUrl")
                 Left(ApiError.JsonValidationError)
             }
           case response                          =>
@@ -117,7 +143,7 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
 
       case _ =>
         logger.warn(s"Received error response from backend: ${response.status}")
-        UnableToCreateSubscriptionError
+        UnableToProcessSubscriptionError
     }
   }
 

--- a/app/models/error/ApiError.scala
+++ b/app/models/error/ApiError.scala
@@ -58,7 +58,7 @@ object ApiError {
 
   case object DuplicateSubmissionError extends ApiError
 
-  case object UnableToCreateSubscriptionError extends ApiError
+  case object UnableToProcessSubscriptionError extends ApiError
 
   case object UnableToCreateEnrolmentError extends ApiError
 

--- a/app/models/requests/SubscriptionRequest.scala
+++ b/app/models/requests/SubscriptionRequest.scala
@@ -18,7 +18,7 @@ package models.requests
 
 import play.api.libs.json.{Json, OFormat, Reads, Writes}
 
-case class CreateSubscriptionRequest(
+case class SubscriptionRequest(
     gbUser: Boolean,
     idNumber: String,
     idType: String,
@@ -27,7 +27,7 @@ case class CreateSubscriptionRequest(
     secondaryContact: Option[SubscriptionContactDetails]
 )
 
-object CreateSubscriptionRequest {
+object SubscriptionRequest {
 
-  implicit val format: OFormat[CreateSubscriptionRequest] = Json.format[CreateSubscriptionRequest]
+  implicit val format: OFormat[SubscriptionRequest] = Json.format[SubscriptionRequest]
 }

--- a/app/models/responses/SubscriptionResponse.scala
+++ b/app/models/responses/SubscriptionResponse.scala
@@ -19,10 +19,10 @@ package models.responses
 import models.SubscriptionId
 import play.api.libs.json.{Json, Reads}
 
-case class CreateSubscriptionResponse(success: SubscriptionIdResponse) {
+case class SubscriptionResponse(success: SubscriptionIdResponse) {
   def subscriptionId: SubscriptionId = SubscriptionId(success.carfReference)
 }
 
-object CreateSubscriptionResponse {
-  implicit lazy val reads: Reads[CreateSubscriptionResponse] = Json.reads[CreateSubscriptionResponse]
+object SubscriptionResponse {
+  implicit lazy val reads: Reads[SubscriptionResponse] = Json.reads[SubscriptionResponse]
 }

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -20,7 +20,7 @@ import cats.data.EitherT
 import connectors.SubscriptionConnector
 import models.error.ApiError.{InternalServerError, MandatoryInformationMissingError}
 import models.error.{ApiError, CarfError}
-import models.requests.CreateSubscriptionRequest
+import models.requests.SubscriptionRequest
 import models.responses.*
 import models.{SubscriptionId, UserAnswers}
 import play.api.Logging

--- a/app/testOnly/controllers/SubscriptionController.scala
+++ b/app/testOnly/controllers/SubscriptionController.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.controllers
+
+import connectors.SubscriptionConnector
+import models.SubscriptionId
+import models.requests.{SubscriptionContactDetails, SubscriptionIndividualContact, SubscriptionOrganisationContact, SubscriptionRequest}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import types.ResultT
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+import scala.language.implicitConversions
+
+class SubscriptionController @Inject() (
+    connector: SubscriptionConnector,
+    val controllerComponents: MessagesControllerComponents,
+    implicit val executionContext: ExecutionContext
+) extends FrontendBaseController
+    with I18nSupport {
+
+  def updateOrgSubscription(name: String): Action[AnyContent] = Action.async { implicit request =>
+
+    val organisation = SubscriptionOrganisationContact(name)
+
+    val contact = SubscriptionContactDetails(
+      individual = None,
+      organisation = Some(organisation),
+      email = "test@email.com",
+      phone = Some("07123456789")
+    )
+
+    val subscriptionRequest = SubscriptionRequest(
+      gbUser = true,
+      idNumber = "XM000123456799",
+      idType = "SAFE",
+      primaryContact = contact,
+      secondaryContact = Some(contact),
+      tradingName = None
+    )
+
+    connector.updateSubscription(subscriptionRequest).processResponse
+
+  }
+
+  def updateIndvSubscription(email: String): Action[AnyContent] = Action.async { implicit request =>
+
+    val individual = SubscriptionIndividualContact("John", "Doe")
+    val contact    = SubscriptionContactDetails(
+      individual = Some(individual),
+      organisation = None,
+      email = email,
+      phone = Some("07123456789")
+    )
+
+    val subscriptionRequest = SubscriptionRequest(
+      gbUser = true,
+      idNumber = "XM000123456799",
+      idType = "SAFE",
+      primaryContact = contact,
+      secondaryContact = None,
+      tradingName = None
+    )
+
+    connector.updateSubscription(subscriptionRequest).processResponse
+  }
+
+  extension (result: ResultT[SubscriptionId]) {
+    private def processResponse =
+      result.value
+        .map {
+          case Right(subscriptionId) => Ok(s"Subscription ID: $subscriptionId")
+          case Left(error)           => Ok(error.toString)
+        }
+  }
+}

--- a/app/testOnly/controllers/SubscriptionController.scala
+++ b/app/testOnly/controllers/SubscriptionController.scala
@@ -35,50 +35,52 @@ class SubscriptionController @Inject() (
 ) extends FrontendBaseController
     with I18nSupport {
 
-  def updateOrgSubscription(name: String): Action[AnyContent] = Action.async { implicit request =>
+  def updateOrgSubscription(name: String, provideOptional: String): Action[AnyContent] = Action.async {
+    implicit request =>
 
-    val organisation = SubscriptionOrganisationContact(name)
+      val organisation = SubscriptionOrganisationContact(name)
 
-    val contact = SubscriptionContactDetails(
-      individual = None,
-      organisation = Some(organisation),
-      email = "test@email.com",
-      phone = Some("07123456789")
-    )
+      val contact = SubscriptionContactDetails(
+        individual = None,
+        organisation = Some(organisation),
+        email = "test@email.com",
+        phone = if provideOptional == "true" then Some("07123456789") else None
+      )
 
-    val subscriptionRequest = SubscriptionRequest(
-      gbUser = true,
-      idNumber = "XM000123456799",
-      idType = "SAFE",
-      primaryContact = contact,
-      secondaryContact = Some(contact),
-      tradingName = None
-    )
+      val subscriptionRequest = SubscriptionRequest(
+        gbUser = true,
+        idNumber = "XM000123456799",
+        idType = "SAFE",
+        primaryContact = contact,
+        secondaryContact = if provideOptional == "true" then Some(contact) else None,
+        tradingName = if provideOptional == "true" then Some("tradingName") else None
+      )
 
-    connector.updateSubscription(subscriptionRequest).processResponse
+      connector.updateSubscription(subscriptionRequest).processResponse
 
   }
 
-  def updateIndvSubscription(email: String): Action[AnyContent] = Action.async { implicit request =>
+  def updateIndvSubscription(email: String, provideOptional: String): Action[AnyContent] = Action.async {
+    implicit request =>
 
-    val individual = SubscriptionIndividualContact("John", "Doe")
-    val contact    = SubscriptionContactDetails(
-      individual = Some(individual),
-      organisation = None,
-      email = email,
-      phone = Some("07123456789")
-    )
+      val individual = SubscriptionIndividualContact("John", "Doe")
+      val contact    = SubscriptionContactDetails(
+        individual = Some(individual),
+        organisation = None,
+        email = email,
+        phone = if provideOptional == "true" then Some("07123456789") else None
+      )
 
-    val subscriptionRequest = SubscriptionRequest(
-      gbUser = true,
-      idNumber = "XM000123456799",
-      idType = "SAFE",
-      primaryContact = contact,
-      secondaryContact = None,
-      tradingName = None
-    )
+      val subscriptionRequest = SubscriptionRequest(
+        gbUser = true,
+        idNumber = "XM000123456799",
+        idType = "SAFE",
+        primaryContact = contact,
+        secondaryContact = None,
+        tradingName = if provideOptional == "true" then Some("tradingName") else None
+      )
 
-    connector.updateSubscription(subscriptionRequest).processResponse
+      connector.updateSubscription(subscriptionRequest).processResponse
   }
 
   extension (result: ResultT[SubscriptionId]) {

--- a/app/utils/SubscriptionHelper.scala
+++ b/app/utils/SubscriptionHelper.scala
@@ -27,14 +27,14 @@ import pages.organisation.*
 
 class SubscriptionHelper {
 
-  def buildSubscriptionRequest(userAnswers: UserAnswers): Option[CreateSubscriptionRequest] =
+  def buildSubscriptionRequest(userAnswers: UserAnswers): Option[SubscriptionRequest] =
     for {
       safeId          <- userAnswers.safeId
       primaryContact  <- buildPrimaryContact(userAnswers)
       tradingName      = getTradingName(userAnswers)
       gbUser           = isGBUser(userAnswers)
       secondaryContact = buildSecondaryContact(userAnswers)
-    } yield CreateSubscriptionRequest(
+    } yield SubscriptionRequest(
       idType = IdentifierType.SAFE,
       idNumber = safeId.value,
       tradingName = tradingName,

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -15,3 +15,6 @@
 GET        /register-for-cryptoasset-reporting/test-only/change-details/manipulate-user-answers/:key/:value        testOnly.controllers.ChangeDetailsManipulateUserAnswersController.changeUserAnswers(key: String, value: String)
 
 GET        /register-for-cryptoasset-reporting/test-only/create-enrolment/:identifierKey/:identifierValue/:verifierKey/:verifierValue        testOnly.controllers.EnrolmentController.createEnrolment(identifierKey: String, identifierValue: String, verifierKey: String, verifierValue: String)
+
+GET        /register-for-cryptoasset-reporting/test-only/update-subscription/organisation/:name        testOnly.controllers.SubscriptionController.updateOrgSubscription(name: String)
+GET        /register-for-cryptoasset-reporting/test-only/update-subscription/individual/:email         testOnly.controllers.SubscriptionController.updateIndvSubscription(email: String)

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -16,5 +16,5 @@ GET        /register-for-cryptoasset-reporting/test-only/change-details/manipula
 
 GET        /register-for-cryptoasset-reporting/test-only/create-enrolment/:identifierKey/:identifierValue/:verifierKey/:verifierValue        testOnly.controllers.EnrolmentController.createEnrolment(identifierKey: String, identifierValue: String, verifierKey: String, verifierValue: String)
 
-GET        /register-for-cryptoasset-reporting/test-only/update-subscription/organisation/:name        testOnly.controllers.SubscriptionController.updateOrgSubscription(name: String)
-GET        /register-for-cryptoasset-reporting/test-only/update-subscription/individual/:email         testOnly.controllers.SubscriptionController.updateIndvSubscription(email: String)
+GET        /register-for-cryptoasset-reporting/test-only/update-subscription/organisation/:name/:provideOptional        testOnly.controllers.SubscriptionController.updateOrgSubscription(name: String, provideOptional: String)
+GET        /register-for-cryptoasset-reporting/test-only/update-subscription/individual/:email/:provideOptional        testOnly.controllers.SubscriptionController.updateIndvSubscription(email: String, provideOptional: String)

--- a/it/test/connectors/SubscriptionConnectorISpec.scala
+++ b/it/test/connectors/SubscriptionConnectorISpec.scala
@@ -20,8 +20,8 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import itutil.ApplicationWithWiremock
 import models.SubscriptionId
-import models.error.ApiError.{AlreadyRegisteredError, InternalServerError, JsonValidationError, NotFoundError, UnableToCreateSubscriptionError}
-import models.requests.{CreateSubscriptionRequest, SubscriptionContactDetails, SubscriptionIndividualContact, SubscriptionOrganisationContact}
+import models.error.ApiError.{AlreadyRegisteredError, InternalServerError, JsonValidationError, NotFoundError, UnableToProcessSubscriptionError}
+import models.requests.{SubscriptionRequest, SubscriptionContactDetails, SubscriptionIndividualContact, SubscriptionOrganisationContact}
 import models.responses.{DisplaySubscriptionContact, DisplaySubscriptionDetails, DisplaySubscriptionIndividual, DisplaySubscriptionResponse, DisplaySubscriptionSuccess}
 import org.scalactic.Prettifier.default
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -52,7 +52,7 @@ class SubscriptionConnectorISpec
     phone = Some("07123456789")
   )
 
-  val validSubscriptionRequest: CreateSubscriptionRequest = CreateSubscriptionRequest(
+  val validSubscriptionRequest: SubscriptionRequest = SubscriptionRequest(
     gbUser = true,
     idNumber = "SAFE123456",
     idType = "SAFE",
@@ -221,7 +221,7 @@ class SubscriptionConnectorISpec
       result shouldBe Left(AlreadyRegisteredError)
     }
 
-    "return UnableToCreateSubscriptionError when backend returns 400 status" in {
+    "return UnableToProcessSubscriptionError when backend returns 400 status" in {
       val errorResponse = Json.obj(
         "status"  -> "Bad request",
         "message" -> "Invalid request"
@@ -237,10 +237,10 @@ class SubscriptionConnectorISpec
       )
 
       val result = connector.createSubscription(validSubscriptionRequest).value.futureValue
-      result shouldBe Left(UnableToCreateSubscriptionError)
+      result shouldBe Left(UnableToProcessSubscriptionError)
     }
 
-    "return UnableToCreateSubscriptionError when backend returns 500" in {
+    "return UnableToProcessSubscriptionError when backend returns 500" in {
       stubFor(
         post(urlPathMatching("/carf-registration/subscription/subscribe"))
           .willReturn(
@@ -251,10 +251,10 @@ class SubscriptionConnectorISpec
       )
 
       val result = connector.createSubscription(validSubscriptionRequest).value.futureValue
-      result shouldBe Left(UnableToCreateSubscriptionError)
+      result shouldBe Left(UnableToProcessSubscriptionError)
     }
 
-    "return UnableToCreateSubscriptionError when backend returns 503" in {
+    "return UnableToProcessSubscriptionError when backend returns 503" in {
       stubFor(
         post(urlPathMatching("/carf-registration/subscription/subscribe"))
           .willReturn(
@@ -265,10 +265,10 @@ class SubscriptionConnectorISpec
       )
 
       val result = connector.createSubscription(validSubscriptionRequest).value.futureValue
-      result shouldBe Left(UnableToCreateSubscriptionError)
+      result shouldBe Left(UnableToProcessSubscriptionError)
     }
 
-    "return UnableToCreateSubscriptionError when response body is not valid JSON" in {
+    "return UnableToProcessSubscriptionError when response body is not valid JSON" in {
       stubFor(
         post(urlPathMatching("/carf-registration/subscription/subscribe"))
           .willReturn(
@@ -279,10 +279,10 @@ class SubscriptionConnectorISpec
       )
 
       val result = connector.createSubscription(validSubscriptionRequest).value.futureValue
-      result shouldBe Left(UnableToCreateSubscriptionError)
+      result shouldBe Left(UnableToProcessSubscriptionError)
     }
 
-    "return UnableToCreateSubscriptionError when response body is empty JSON" in {
+    "return UnableToProcessSubscriptionError when response body is empty JSON" in {
       stubFor(
         post(urlPathMatching("/carf-registration/subscription/subscribe"))
           .willReturn(
@@ -293,7 +293,7 @@ class SubscriptionConnectorISpec
       )
 
       val result = connector.createSubscription(validSubscriptionRequest).value.futureValue
-      result shouldBe Left(UnableToCreateSubscriptionError)
+      result shouldBe Left(UnableToProcessSubscriptionError)
     }
 
     "handle subscription request with no secondary contact" in {
@@ -312,6 +312,127 @@ class SubscriptionConnectorISpec
       result shouldBe Right(SubscriptionId("CARF123456"))
     }
 
+  }
+  
+  "updateSubscription" should {
+    "successfully update a subscription and return a subscription ID" in {
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/amend"))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(validSubscriptionResponseJson)
+          )
+      )
+
+      val result = connector.updateSubscription(validSubscriptionRequest).value.futureValue
+      result shouldBe Right(SubscriptionId("CARF123456"))
+    }
+
+    "return JsonValidationError when response JSON is invalid" in {
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/amend"))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(Json.toJson("invalid response").toString)
+          )
+      )
+
+      val result = connector.updateSubscription(validSubscriptionRequest).value.futureValue
+      result shouldBe Left(JsonValidationError)
+    }
+
+    "return JsonValidationError when response JSON structure is incorrect" in {
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/amend"))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody("""{"incorrect": "structure"}""")
+          )
+      )
+
+      val result = connector.updateSubscription(validSubscriptionRequest).value.futureValue
+      result shouldBe Left(JsonValidationError)
+    }
+
+    "return UnableToProcessSubscriptionError when backend returns 400 status" in {
+      val testApiErrorDetailResponseJson: String = generateErrorResponseJson("400")
+
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/subscribe"))
+          .willReturn(
+            aResponse()
+              .withStatus(BAD_REQUEST)
+              .withBody(testApiErrorDetailResponseJson)
+          )
+      )
+
+      val result = connector.updateSubscription(validSubscriptionRequest).value.futureValue
+      result shouldBe Left(UnableToProcessSubscriptionError)
+    }
+
+    "return UnableToProcessSubscriptionError when backend returns 500" in {
+
+      val testApiErrorDetailResponseJson: String = generateErrorResponseJson("500")
+
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/amend"))
+          .willReturn(
+            aResponse()
+              .withStatus(INTERNAL_SERVER_ERROR)
+              .withBody(testApiErrorDetailResponseJson)
+          )
+      )
+
+      val result = connector.updateSubscription(validSubscriptionRequest).value.futureValue
+      result shouldBe Left(UnableToProcessSubscriptionError)
+    }
+
+    "return UnableToProcessSubscriptionError when response body is not valid JSON" in {
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/amend"))
+          .willReturn(
+            aResponse()
+              .withStatus(INTERNAL_SERVER_ERROR)
+              .withBody("Not a JSON response")
+          )
+      )
+
+      val result = connector.updateSubscription(validSubscriptionRequest).value.futureValue
+      result shouldBe Left(UnableToProcessSubscriptionError)
+    }
+
+    "return UnableToProcessSubscriptionError when response body is empty JSON" in {
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/amend"))
+          .willReturn(
+            aResponse()
+              .withStatus(BAD_REQUEST)
+              .withBody("{}")
+          )
+      )
+
+      val result = connector.updateSubscription(validSubscriptionRequest).value.futureValue
+      result shouldBe Left(UnableToProcessSubscriptionError)
+    }
+
+    "handle subscription request with no secondary contact" in {
+      val validRequestWithoutSecondaryContact = validSubscriptionRequest.copy(secondaryContact = None)
+
+      stubFor(
+        put(urlPathMatching("/carf-registration/subscription/amend"))
+          .willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(validSubscriptionResponseJson)
+          )
+      )
+
+      val result = connector.updateSubscription(validRequestWithoutSecondaryContact).value.futureValue
+      result shouldBe Right(SubscriptionId("CARF123456"))
+    }
   }
 
   "displaySubscription" should {
@@ -446,4 +567,20 @@ class SubscriptionConnectorISpec
     }
 
   }
+
+  def generateErrorResponseJson(errorCode: String): String =
+    s"""{
+      |  "errorDetail": {
+      |    "errorCode": "$errorCode",
+      |    "errorMessage": "Test Error Message",
+      |    "source": "Test",
+      |    "sourceFaultDetail": {
+      |      "detail": [
+      |        "Test Error Detail"
+      |      ]
+      |    },
+      |    "timestamp": "2020-09-25T21:54:12.015Z",
+      |    "correlationId": "1ae81b45-41b4-4642-ae1c-db1126900001"
+      |  }
+      |}""".stripMargin
 }

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -22,7 +22,7 @@ import connectors.SubscriptionConnector
 import models.*
 import models.error.ApiError
 import models.error.ApiError.{InternalServerError, MandatoryInformationMissingError}
-import models.requests.CreateSubscriptionRequest
+import models.requests.SubscriptionRequest
 import models.responses.{DisplaySubscriptionContact, DisplaySubscriptionDetails, DisplaySubscriptionIndividual, DisplaySubscriptionResponse, DisplaySubscriptionSuccess}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, reset, verify, when}
@@ -102,18 +102,18 @@ class SubscriptionServiceSpec extends SpecBase {
   "SubscriptionService" - {
     "subscribe" - {
       "should successfully create subscription with valid user answers" in {
-        when(mockConnector.createSubscription(any[CreateSubscriptionRequest])(any(), any())).thenReturn(
+        when(mockConnector.createSubscription(any[SubscriptionRequest])(any(), any())).thenReturn(
           EitherT.rightT[Future, ApiError](exampleSubscriptionId)
         )
 
         val result = testService.subscribe(userAnswers).value.futureValue
 
         result mustBe Right(exampleSubscriptionId)
-        verify(mockConnector).createSubscription(any[CreateSubscriptionRequest])(any(), any())
+        verify(mockConnector).createSubscription(any[SubscriptionRequest])(any(), any())
       }
 
       "should return error when connector fails" in {
-        when(mockConnector.createSubscription(any[CreateSubscriptionRequest])(any(), any())).thenReturn(
+        when(mockConnector.createSubscription(any[SubscriptionRequest])(any(), any())).thenReturn(
           EitherT.leftT[Future, SubscriptionId](InternalServerError)
         )
 
@@ -128,7 +128,7 @@ class SubscriptionServiceSpec extends SpecBase {
         result mustBe Left(
           MandatoryInformationMissingError("There has been an error building the subscription request from userAnswers")
         )
-        verify(mockConnector, never()).createSubscription(any[CreateSubscriptionRequest])(any(), any())
+        verify(mockConnector, never()).createSubscription(any[SubscriptionRequest])(any(), any())
       }
     }
 

--- a/test/utils/SubscriptionHelperSpec.scala
+++ b/test/utils/SubscriptionHelperSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import models.*
 import models.JourneyType.*
 import models.countries.CountryUk
-import models.requests.{CreateSubscriptionRequest, SubscriptionContactDetails, SubscriptionIndividualContact, SubscriptionOrganisationContact}
+import models.requests.{SubscriptionContactDetails, SubscriptionIndividualContact, SubscriptionOrganisationContact, SubscriptionRequest}
 import pages.*
 import pages.individual.*
 import pages.individualWithoutId.{IndFindAddressPage, IndWithoutIdAddressPagePrePop, IndWithoutNinoNamePage}
@@ -121,7 +121,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result                          mustBe defined
           result.get.primaryContact.phone mustBe None
@@ -138,7 +138,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }
@@ -154,7 +154,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }
@@ -181,7 +181,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe defined
           val request = result.get
@@ -216,7 +216,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result            mustBe defined
           result.get.gbUser mustBe true
@@ -239,7 +239,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result            mustBe defined
           result.get.gbUser mustBe true
@@ -253,7 +253,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }
@@ -280,7 +280,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe defined
           val request = result.get
@@ -309,7 +309,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }
@@ -341,7 +341,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe defined
           val request = result.get
@@ -377,7 +377,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe defined
           val request = result.get
@@ -433,7 +433,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe defined
           val request = result.get
@@ -500,7 +500,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }
@@ -519,7 +519,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }
@@ -553,7 +553,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result                      mustBe defined
           result.get.secondaryContact mustBe None
@@ -588,7 +588,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result                      mustBe defined
           result.get.secondaryContact mustBe None
@@ -625,7 +625,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe defined
           val request = result.get
@@ -675,7 +675,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe defined
           val request = result.get
@@ -697,7 +697,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }
@@ -725,7 +725,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result                 mustBe defined
           result.get.tradingName mustBe Some(testBusinessName)
@@ -779,7 +779,7 @@ class SubscriptionHelperSpec extends SpecBase {
             .success
             .value
 
-          val result: Option[CreateSubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
+          val result: Option[SubscriptionRequest] = subscriptionHelper.buildSubscriptionRequest(userAnswers)
 
           result mustBe None
         }


### PR DESCRIPTION

# How to test

GET        /register-for-cryptoasset-reporting/test-only/update-subscription/organisation/:name/:provideOptional
GET        /register-for-cryptoasset-reporting/test-only/update-subscription/individual/:email/:provideOptional

	• Primary Email for Individual
	• Secondary name for organisation
	• Looks at first two characters
	• :provideOptional is used to return optional fields or not such as:
		○ Organisation: phone, trading name and secondary contact. 
		○ Individual: phone, trading name (even though not relevant)

"UU" => unprocessableEntity422Response
"VV" => forbiddenResponse
"WW" => notAllowedResponse
"XX" => badRequest400Response
"YY" => internalServerError500Response
"ZZ" => serviceUnavailable503Response
Anything Else  => successfulSubscriptionResponse("XCARF000000001")
