### PR TITLE
Remove PII from log statements

### DIFF
--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -72,10 +72,6 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
         http.post(submissionUrl)
       }
 
-    logger.debug(
-      s"[SubscriptionConnector] $action subscription with request:\n ${Json.prettyPrint(Json.toJson(request))}"
-    )
-
     ResultT.fromFuture(
       requestBuilder
         .withBody(Json.toJson(request))

--- a/app/controllers/actions/CarfIdRetrievalAction.scala
+++ b/app/controllers/actions/CarfIdRetrievalAction.scala
@@ -80,8 +80,7 @@ class CarfIdRetrievalActionExtractor @Inject() (
             Future.successful(Redirect(controllers.routes.IndexController.onPageLoad(NormalMode)))
         }
       case _                             =>
-        val msg = "Unable to retrieve internal id"
-        logger.warn(msg)
+        logger.warn("Unable to retrieve internal id")
         throw AuthorisationException.fromString(msg)
     } recover {
       case _: NoActiveSession        =>

--- a/app/services/AuditService.scala
+++ b/app/services/AuditService.scala
@@ -116,7 +116,6 @@ class AuditService @Inject (auditConnector: AuditConnector)(using ec: ExecutionC
     } yield ()
 
   private def convertToExtendedEvent(eventJsValue: JsValue, auditType: String) = {
-    logger.debug(s"Sending Audit event detail:\n ${Json.prettyPrint(eventJsValue)}")
     ExtendedDataEvent(
       auditSource = "carf-registration-frontend",
       auditType = auditType,

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -103,7 +103,7 @@ class CheckYourAnswersHelper @Inject() extends Logging {
             None
         }
       } else {
-        logger.warn(s"Individual with NINO requires user to have a nino. When questioned, user answered: $haveNino")
+        logger.warn(s"Individual with NINO requires user to have a nino. When questioned, user answered false")
         None
       }
   }.flatten.map(Section(messages("checkYourAnswers.summaryListTitle.individualDetails"), _))
@@ -144,7 +144,7 @@ class CheckYourAnswersHelper @Inject() extends Logging {
         }
       } else {
         logger.warn(
-          s"Individual without NINO requires user to NOT have a nino. When questioned, user answered: $haveNino"
+          s"Individual without NINO requires user to NOT have a nino. When questioned, user answered true"
         )
         None
       }


### PR DESCRIPTION
Remove PII from log statements. In some cases, I've just removed the log statement where it isn't providing value